### PR TITLE
Update swagger.yaml

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -892,7 +892,7 @@ paths:
     post:
       tags:
         - hierarchy
-      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must be unique. If no ID is supplied, it is generated before insertion. Query ?parent=nodeId - the sub-tree will be inserted as first child; query ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
+      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must be unique. If no ID is supplied, it is generated before insertion. Query ?parent=nodeId - the sub-tree will be inserted as first child; query ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level. Without query string, the node (sub-tree) is inserted as first element at root level.
       operationId: createHierarchy
       consumes:
         - application/json-patch+json
@@ -912,7 +912,7 @@ paths:
     put:
       tags:
         - hierarchy
-      summary: Update an existing hierarchy (sub-tree) with supplied nodes; the supplied ID must exist somewhere in any hierarchy. Query ?parent=nodeId - the sub-tree will be moved and inserted as first child; query ?predecessor=nodeId - the sub-tree will be moved and inserted after the specified node.
+      summary: Update an existing hierarchy (sub-tree) with supplied nodes; the supplied ID must exist somewhere in any hierarchy. Query ?parent=nodeId - the sub-tree will be moved and inserted as first child; query ?predecessor=nodeId - the sub-tree will be moved and inserted after the specified node. Without query string, the node (sub-tree) is not moved.
       operationId: updateHierarchy
       consumes:
         - application/json-patch+json

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -742,7 +742,7 @@ paths:
     post:
       tags:
         - hierarchy
-      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must be unique. If no ID is supplied, it is generated before insertion. ?parent=nodeId - the sub-tree will be inserted as first child; ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
+      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must be unique. If no ID is supplied, it is generated before insertion. Query ?parent=nodeId - the sub-tree will be inserted as first child; query ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
       operationId: createHierarchy
       consumes:
         - application/json-patch+json
@@ -762,7 +762,7 @@ paths:
     put:
       tags:
         - hierarchy
-      summary: Update an existing hierarchy (sub-tree) with supplied nodes; the supplied ID must exist somewhere in any hierarchy.
+      summary: Update an existing hierarchy (sub-tree) with supplied nodes; the supplied ID must exist somewhere in any hierarchy. Query ?parent=nodeId - the sub-tree will be moved and inserted as first child; query ?predecessor=nodeId - the sub-tree will be moved and inserted after the specified node.
       operationId: updateHierarchy
       consumes:
         - application/json-patch+json

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -217,6 +217,8 @@ paths:
             type: array
             items:
               $ref: '#/definitions/dataType'
+        '404':
+          description: Not Found
   '/specif/v1.0/propertyClasses':
     get:
       tags:
@@ -322,6 +324,31 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
+  '/specif/v1.0/propertyClasses/{id}/allRevisions':
+    get:
+      tags:
+        - propertyClass
+      summary: Return all property class revisions for the supplied ID
+      operationId: getAllPropertyClassRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/propertyClass'
+        '404':
+          description: Not Found
   '/specif/v1.0/resourceClasses':
     get:
       tags:
@@ -427,6 +454,31 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
+  '/specif/v1.0/resourceClasses/{id}/allRevisions':
+    get:
+      tags:
+        - resourceClass
+      summary: Return all resource class revisions for the supplied ID
+      operationId: getAllResourceClassRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/resourceClass'
+        '404':
+          description: Not Found
   '/specif/v1.0/statementClass':
     get:
       tags:
@@ -532,6 +584,31 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
+  '/specif/v1.0/statementClasses/{id}/allRevisions':
+    get:
+      tags:
+        - statementClass
+      summary: Return all statement class revisions for the supplied ID
+      operationId: getAllStatementClassRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/statementClass'
+        '404':
+          description: Not Found
   '/specif/v1.0/resources':
     get:
       tags:
@@ -637,6 +714,31 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
+  '/specif/v1.0/resources/{id}/allRevisions':
+    get:
+      tags:
+        - resource
+      summary: Return all resource revisions for the supplied ID
+      operationId: getAllResourceRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/resource'
+        '404':
+          description: Not Found
   '/specif/v1.0/statements':
     get:
       tags:
@@ -738,6 +840,31 @@ paths:
           description: Success
         '400':
           description: Bad Request
+        '404':
+          description: Not Found
+  '/specif/v1.0/statements/{id}/allRevisions':
+    get:
+      tags:
+        - statement
+      summary: Return all statement revisions for the supplied ID
+      operationId: getAllStatementRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/statement'
         '404':
           description: Not Found
   '/specif/v1.0/hierarchies':
@@ -847,6 +974,31 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
+  '/specif/v1.0/hierarchies/{id}/allRevisions':
+    get:
+      tags:
+        - hierarchy
+      summary: Return all hierarchy revisions for the supplied ID
+      operationId: getAllHierarchyRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/node'
+        '404':
+          description: Not Found
   '/specif/v1.0/files':
     get:
       tags:
@@ -952,6 +1104,31 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
+  '/specif/v1.0/files/{id}/allRevisions':
+    get:
+      tags:
+        - file
+      summary: Return all file revisions for the supplied ID
+      operationId: getAllFileRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/file'
+        '404':
+          description: Not Found
 definitions:
   project:
     type: object

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -33,7 +33,7 @@ paths:
     post:
       tags:
         - project
-      summary: Create a project with supplied elements; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
+      summary: Create a project with supplied elements; the supplied ID must be unique. If no ID is supplied, it is generated before insertion.
       operationId: createProject
       consumes:
         - application/json-patch+json
@@ -114,7 +114,7 @@ paths:
     post:
       tags:
         - dataType
-      summary: Create a data type; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
+      summary: Create a data type; the supplied ID must be unique. If no ID is supplied, it is generated before insertion.
       operationId: createDataType
       consumes:
         - application/json-patch+json
@@ -217,7 +217,7 @@ paths:
     post:
       tags:
         - propertyClass
-      summary: Create a property class; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
+      summary: Create a property class; the supplied ID must be unique. If no ID is supplied, it is generated before insertion.
       operationId: createPropertyClass
       consumes:
         - application/json-patch+json
@@ -322,7 +322,7 @@ paths:
     post:
       tags:
         - resourceClass
-      summary: Create a resource class; the supplied ID must be unique in the project scope. 
+      summary: Create a resource class; the supplied ID must be unique. 
       operationId: createResourceClass
       consumes:
         - application/json-patch+json
@@ -427,7 +427,7 @@ paths:
     post:
       tags:
         - statementClass
-      summary: Create a statement class; the supplied ID must be unique in the project scope. 
+      summary: Create a statement class; the supplied ID must be unique. 
       operationId: createStatementClass
       consumes:
         - application/json-patch+json
@@ -532,7 +532,7 @@ paths:
     post:
       tags:
         - resource
-      summary: Create a resource; the supplied ID must be unique in the project scope. 
+      summary: Create a resource; the supplied ID must be unique. 
       operationId: createResource
       consumes:
         - application/json-patch+json
@@ -637,7 +637,7 @@ paths:
     post:
       tags:
         - statement
-      summary: Create a statement; the supplied ID must be unique in the project scope. 
+      summary: Create a statement; the supplied ID must be unique. 
       operationId: createStatement
       consumes:
         - application/json-patch+json
@@ -717,8 +717,6 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-        '901':
-          description: Is Referenced
   '/specif/v1.0/hierarchies':
     get:
       tags:
@@ -744,7 +742,7 @@ paths:
     post:
       tags:
         - hierarchy
-      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion. ?parent=nodeId - the sub-tree will be inserted as first child; ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
+      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must be unique. If no ID is supplied, it is generated before insertion. ?parent=nodeId - the sub-tree will be inserted as first child; ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
       operationId: createHierarchy
       consumes:
         - application/json-patch+json
@@ -849,7 +847,7 @@ paths:
     post:
       tags:
         - file
-      summary: Create a file; the supplied ID must be unique in the project scope. 
+      summary: Create a file; the supplied ID must be unique. 
       operationId: createFile
       consumes:
         - application/json-patch+json
@@ -929,6 +927,8 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
+        '901':
+          description: Is Referenced
 definitions:
   project:
     type: object

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -30,12 +30,10 @@ paths:
               $ref: '#/definitions/project'
         '400':
           description: Bad Request
-        '404':
-          description: Not Found
     post:
       tags:
         - project
-      summary: Create a project with supplied elements; the supplied ID must not exist.
+      summary: Create a project with supplied elements; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
       operationId: createProject
       consumes:
         - application/json-patch+json
@@ -50,8 +48,6 @@ paths:
           description: Success
         '400':
           description: Bad Request
-        '404':
-          description: Not Found
   '/specif/v1.0/projects/{pid}':
     get:
       tags:
@@ -99,7 +95,7 @@ paths:
     get:
       tags:
         - dataType
-      summary: Return all dataTypes.
+      summary: Return all data types.
       operationId: getAllDataTypes
       consumes: []
       produces:
@@ -120,12 +116,10 @@ paths:
               $ref: '#/definitions/dataType'
         '400':
           description: Bad Request
-        '404':
-          description: Not Found
     post:
       tags:
         - dataType
-      summary: Create a dataType; the supplied ID must not exist.
+      summary: Create a data type; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
       operationId: createDataType
       consumes:
         - application/json-patch+json
@@ -145,12 +139,10 @@ paths:
           description: Success
         '400':
           description: Bad Request
-        '404':
-          description: Not Found
     put:
       tags:
         - dataType
-      summary: Update the dataType; the supplied ID must exist.
+      summary: Update the data type; the supplied ID must exist.
       operationId: updateDataType
       consumes:
         - application/json-patch+json
@@ -176,7 +168,7 @@ paths:
     get:
       tags:
         - dataType
-      summary: Return the dataType with the given ID.
+      summary: Return the data type with the given ID.
       operationId: getDataTypeById
       consumes: []
       produces:
@@ -202,7 +194,7 @@ paths:
     delete:
       tags:
         - dataType
-      summary: Delete the dataType; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      summary: Delete the data type; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
       operationId: deleteDataTypeById
       consumes: []
       produces:
@@ -216,6 +208,126 @@ paths:
         - name: id
           in: path
           description: The hierarchy ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+        '901':
+          description: Is Referenced
+  /specif/v1.0/propertyClasses:
+    get:
+      tags:
+        - propertyClass
+      summary: Return all property classes.
+      operationId: GetAllPropertyClasses
+      consumes: []
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/PropertyClass'
+        '400':
+          description: Bad Request
+    post:
+      tags:
+        - propertyClass
+      summary: Create a property class; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
+      operationId: createPropertyClass
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+    put:
+      tags:
+        - propertyClass
+      summary: Update the property class; the supplied ID must exist.
+      operationId: updatePropertyClass
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+  '/specif/v1.0/propertyClasses/{id}':
+    get:
+      tags:
+        - propertyClass
+      summary: Return the property class with the given ID.
+      operationId: GetPropertyClassById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The property class ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/PropertyClass'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    delete:
+      tags:
+        - propertyClass
+      summary: Delete the property class; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      operationId: deletePropertyClassById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: The property class ID.
           required: true
           type: string
       responses:
@@ -257,7 +369,7 @@ paths:
     post:
       tags:
         - hierarchy
-      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must not exist. ?parent=nodeId - the sub-tree will be inserted as first child; ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
+      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion. ?parent=nodeId - the sub-tree will be inserted as first child; ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
       operationId: createHierarchy
       consumes:
         - application/json-patch+json
@@ -530,100 +642,6 @@ paths:
             type: array
             items:
               type: string
-  /specif/v1.0/property-classes:
-    get:
-      tags:
-        - PropertyClass
-      summary: Returns all property classes with alll available revisions.
-      operationId: GetAllPropertyClasses
-      consumes: []
-      produces:
-        - application/json
-      parameters: []
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/PropertyClass'
-        '400':
-          description: Bad Request
-  '/specif/v1.0/property-classes/{id}':
-    get:
-      tags:
-        - PropertyClass
-      summary: Returns the main/latest revision of the property class with the given ID.
-      operationId: GetPropertyClassById
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/PropertyClass'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found or No Permission
-  '/specif/v1.0/property-classes/{id}/revisions':
-    get:
-      tags:
-        - PropertyClass
-      summary: Returns all property class revisions for the given id.
-      operationId: GetAllPropertyClassRevisions
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/PropertyClass'
-  '/specif/v1.0/property-classes/{id}/revisions/{revision}':
-    get:
-      tags:
-        - PropertyClass
-      summary: Returns the property class with the specific revision.
-      operationId: GetPropertyClassRevision
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The property class ID.
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: The property class revision.
-          required: true
-          type: string
-      responses:
-        '201':
-          description: Success
-          schema:
-            $ref: '#/definitions/StatementClass'
-        '404':
-          description: Not Found
   '/specif/v1.0/resources/{id}':
     get:
       tags:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -194,7 +194,30 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  /specif/v1.0/propertyClasses:
+  '/specif/v1.0/dataTypes/{id}/allRevisions':
+    get:
+      tags:
+        - dataType
+      summary: Return all data type revisions for the supplied ID
+      operationId: getAllDataTypeRevisions
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: ''
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/dataType'
+  '/specif/v1.0/propertyClasses':
     get:
       tags:
         - propertyClass
@@ -299,7 +322,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  /specif/v1.0/resourceClasses:
+  '/specif/v1.0/resourceClasses':
     get:
       tags:
         - resourceClass
@@ -404,7 +427,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  /specif/v1.0/statementClass:
+  '/specif/v1.0/statementClass':
     get:
       tags:
         - statementClass
@@ -509,7 +532,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  /specif/v1.0/resources:
+  '/specif/v1.0/resources':
     get:
       tags:
         - resource
@@ -614,7 +637,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  /specif/v1.0/statements:
+  '/specif/v1.0/statements':
     get:
       tags:
         - statement
@@ -824,7 +847,7 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  /specif/v1.0/files:
+  '/specif/v1.0/files':
     get:
       tags:
         - file

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -48,7 +48,7 @@ paths:
           description: Success
         '400':
           description: Bad Request
-  '/specif/v1.0/projects/{pid}':
+  '/specif/v1.0/projects/{id}':
     get:
       tags:
         - project
@@ -58,7 +58,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: pid
+        - name: id
           in: path
           description: The project ID.
           required: true
@@ -79,7 +79,7 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: pid
+        - name: id
           in: path
           description: The project ID.
           required: true
@@ -91,36 +91,31 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/projects/{pid}/datatypes':
+  '/specif/v1.0/dataTypes':
     get:
       tags:
-        - datatype
+        - dataType
       summary: Return all data types.
-      operationId: getalldatatypes
+      operationId: getAllDataTypes
       consumes: []
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
+      parameters: []
       responses:
         '200':
-          description: List of datatypes suceessfully returned.
+          description: List of dataTypes suceessfully returned.
           schema:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/datatype'
+              $ref: '#/definitions/dataType'
         '400':
           description: Bad Request
     post:
       tags:
-        - datatype
+        - dataType
       summary: Create a data type; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
-      operationId: createdatatype
+      operationId: createDataType
       consumes:
         - application/json-patch+json
         - application/json
@@ -128,12 +123,7 @@ paths:
         - application/*+json
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
+      parameters: []
       responses:
         '201':
           description: Success
@@ -141,9 +131,9 @@ paths:
           description: Bad Request
     put:
       tags:
-        - datatype
+        - dataType
       summary: Update the data type; the supplied ID must exist.
-      operationId: updatedatatype
+      operationId: updateDataType
       consumes:
         - application/json-patch+json
         - application/json
@@ -151,12 +141,7 @@ paths:
         - application/*+json
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
+      parameters: []
       responses:
         '200':
           description: Success
@@ -164,21 +149,16 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/projects/{pid}/datatypes/{id}':
+  '/specif/v1.0/dataTypes/{id}':
     get:
       tags:
-        - datatype
+        - dataType
       summary: Return the data type with the given ID.
-      operationId: getdatatype
+      operationId: getDataTypeById
       consumes: []
       produces:
         - application/json
       parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
         - name: id
           in: path
           description: The data type ID.
@@ -193,18 +173,13 @@ paths:
           description: Not Found
     delete:
       tags:
-        - datatype
+        - dataType
       summary: Delete the data type; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
-      operationId: deletedatatype
+      operationId: deleteDataTypeById
       consumes: []
       produces:
         - application/json
       parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
         - name: id
           in: path
           description: The hierarchy ID.
@@ -219,12 +194,12 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  /specif/v1.0/propertyclasses:
+  /specif/v1.0/propertyClasses:
     get:
       tags:
-        - propertyclass
+        - propertyClass
       summary: Return all property classes.
-      operationId: Getallpropertyclasses
+      operationId: GetAllPropertyClasses
       consumes: []
       produces:
         - application/json
@@ -236,14 +211,14 @@ paths:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/propertyclass'
+              $ref: '#/definitions/propertyClass'
         '400':
           description: Bad Request
     post:
       tags:
-        - propertyclass
+        - propertyClass
       summary: Create a property class; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
-      operationId: createpropertyclass
+      operationId: createPropertyClass
       consumes:
         - application/json-patch+json
         - application/json
@@ -251,12 +226,7 @@ paths:
         - application/*+json
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
+      parameters: []
       responses:
         '201':
           description: Success
@@ -264,9 +234,9 @@ paths:
           description: Bad Request
     put:
       tags:
-        - propertyclass
+        - propertyClass
       summary: Update the property class; the supplied ID must exist.
-      operationId: updatepropertyclass
+      operationId: updatePropertyClass
       consumes:
         - application/json-patch+json
         - application/json
@@ -274,12 +244,7 @@ paths:
         - application/*+json
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
+      parameters: []
       responses:
         '200':
           description: Success
@@ -287,12 +252,12 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/propertyclasses/{id}':
+  '/specif/v1.0/propertyClasses/{id}':
     get:
       tags:
-        - propertyclass
+        - propertyClass
       summary: Return the property class with the given ID.
-      operationId: Getpropertyclass
+      operationId: GetPropertyClassById
       consumes: []
       produces:
         - application/json
@@ -306,25 +271,20 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/propertyclass'
+            $ref: '#/definitions/propertyClass'
         '400':
           description: Bad Request
         '404':
           description: Not Found or No Permission
     delete:
       tags:
-        - propertyclass
+        - propertyClass
       summary: Delete the property class; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
-      operationId: deletepropertyclass
+      operationId: deletePropertyClassById
       consumes: []
       produces:
         - application/json
       parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
         - name: id
           in: path
           description: The property class ID.
@@ -339,7 +299,427 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  '/specif/v1.0/projects/{pid}/hierarchies':
+  /specif/v1.0/resourceClasses:
+    get:
+      tags:
+        - resourceClass
+      summary: Return all resource classes.
+      operationId: GetAllResourceClasses
+      consumes: []
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/resourceClass'
+        '400':
+          description: Bad Request
+    post:
+      tags:
+        - resourceClass
+      summary: Create a resource class; the supplied ID must be unique in the project scope. 
+      operationId: createResourceClass
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+    put:
+      tags:
+        - resourceClass
+      summary: Update the resource class; the supplied ID must exist.
+      operationId: updateResourceClass
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+  '/specif/v1.0/resourceClasses/{id}':
+    get:
+      tags:
+        - resourceClass
+      summary: Return the resource class with the given ID.
+      operationId: GetResourceClassById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The resource class ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/resourceClass'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    delete:
+      tags:
+        - resourceClass
+      summary: Delete the resource class; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      operationId: deleteResourceClassById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The resource class ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+        '901':
+          description: Is Referenced
+  /specif/v1.0/statementClass:
+    get:
+      tags:
+        - statementClass
+      summary: Return all statement classes.
+      operationId: GetAllStatementClasses
+      consumes: []
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/statementClass'
+        '400':
+          description: Bad Request
+    post:
+      tags:
+        - statementClass
+      summary: Create a statement class; the supplied ID must be unique in the project scope. 
+      operationId: createStatementClass
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+    put:
+      tags:
+        - statementClass
+      summary: Update the statement class; the supplied ID must exist.
+      operationId: updateStatementClass
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+  '/specif/v1.0/statementClasses/{id}':
+    get:
+      tags:
+        - statementClass
+      summary: Return the statement class with the given ID.
+      operationId: GetStatementClassById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The statement class ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/statementClass'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    delete:
+      tags:
+        - statementClass
+      summary: Delete the statement class; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      operationId: deleteStatementClassById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The statement class ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+        '901':
+          description: Is Referenced
+  /specif/v1.0/resources:
+    get:
+      tags:
+        - resource
+      summary: Return all resources.
+      operationId: GetAllResources
+      consumes: []
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/resource'
+        '400':
+          description: Bad Request
+    post:
+      tags:
+        - resource
+      summary: Create a resource; the supplied ID must be unique in the project scope. 
+      operationId: createResource
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+    put:
+      tags:
+        - resource
+      summary: Update the resource; the supplied ID must exist.
+      operationId: updateResource
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+  '/specif/v1.0/resources/{id}':
+    get:
+      tags:
+        - resource
+      summary: Return the resource with the given ID.
+      operationId: GetResourceById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The resource ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/resource'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    delete:
+      tags:
+        - resource
+      summary: Delete the resource; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      operationId: deleteResourceById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The resource ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+        '901':
+          description: Is Referenced
+  /specif/v1.0/statements:
+    get:
+      tags:
+        - statement
+      summary: Return all statements.
+      operationId: GetAllStatements
+      consumes: []
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/statement'
+        '400':
+          description: Bad Request
+    post:
+      tags:
+        - statement
+      summary: Create a statement; the supplied ID must be unique in the project scope. 
+      operationId: createStatement
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+    put:
+      tags:
+        - statement
+      summary: Update the statement; the supplied ID must exist.
+      operationId: updateStatement
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+  '/specif/v1.0/statements/{id}':
+    get:
+      tags:
+        - statement
+      summary: Return the statement with the given ID.
+      operationId: GetStatementById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The statement ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/statement'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    delete:
+      tags:
+        - statement
+      summary: Delete the statement; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      operationId: deleteStatementById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The statement ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
+        '901':
+          description: Is Referenced
+  '/specif/v1.0/hierarchies':
     get:
       tags:
         - hierarchy
@@ -348,12 +728,7 @@ paths:
       consumes: []
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
+      parameters: []
       responses:
         '200':
           description: Success
@@ -378,18 +753,7 @@ paths:
         - application/*+json
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
-        - name: hierarchy
-          in: body
-          description: ''
-          required: false
-          schema:
-            $ref: '#/definitions/node'
+      parameters: []
       responses:
         '201':
           description: Success
@@ -409,18 +773,7 @@ paths:
         - application/*+json
       produces:
         - application/json
-      parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
-        - name: hierarchy
-          in: body
-          description: ''
-          required: false
-          schema:
-            $ref: '#/definitions/node'
+      parameters: []
       responses:
         '200':
           description: Success
@@ -428,7 +781,7 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/projects/{pid}/hierarchies/{id}':
+  '/specif/v1.0/hierarchies/{id}':
     get:
       tags:
         - hierarchy
@@ -438,11 +791,6 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
         - name: id
           in: path
           description: The hierarchy ID.
@@ -466,11 +814,6 @@ paths:
       produces:
         - application/json
       parameters:
-        - name: pid
-          in: path
-          description: The project ID.
-          required: true
-          type: string
         - name: id
           in: path
           description: The hierarchy ID.
@@ -483,12 +826,12 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/nodes/root-nodes':
+  /specif/v1.0/files:
     get:
       tags:
-        - Node
-      summary: Returns all available root nodes.
-      operationId: GetRootNodes
+        - file
+      summary: Return all files.
+      operationId: GetAllFiles
       consumes: []
       produces:
         - application/json
@@ -500,740 +843,90 @@ paths:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/node'
-  '/specif/v1.0/nodes/{parentNodeId}/child-nodes':
-    get:
+              $ref: '#/definitions/file'
+        '400':
+          description: Bad Request
+    post:
       tags:
-        - Node
-      summary: Returns one level of child nodes for a parent node.
-      operationId: GetChildNodes
-      consumes: []
+        - file
+      summary: Create a file; the supplied ID must be unique in the project scope. 
+      operationId: createFile
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
       produces:
         - application/json
-      parameters:
-        - name: parentNodeId
-          in: path
-          required: true
-          type: string
+      parameters: []
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+    put:
+      tags:
+        - file
+      summary: Update the file; the supplied ID must exist.
+      operationId: updateFile
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
       responses:
         '200':
           description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/node'
         '400':
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/nodes/parent/{parentNodeId}':
-    post:
+  '/specif/v1.0/files/{id}':
+    get:
       tags:
-        - Node
-      summary: Add a new node to a parent node with given ID.
-      operationId: AddChildNode
-      consumes:
-        - application/json-patch+json
-        - application/json
-        - text/json
-        - application/*+json
+        - file
+      summary: Return the file with the given ID.
+      operationId: GetFileById
+      consumes: []
       produces:
         - application/json
       parameters:
-        - name: parentNodeId
+        - name: id
           in: path
-          description: The parent node ID.
+          description: The file ID.
           required: true
           type: string
-        - name: node
-          in: body
-          description: The new child node.
-          required: false
-          schema:
-            $ref: '#/definitions/node'
       responses:
         '200':
           description: Success
-  /specif/v1.0/nodes:
-    put:
-      tags:
-        - Node
-      summary: Updates an existing node.
-      operationId: UpdateNode
-      consumes:
-        - application/json-patch+json
-        - application/json
-        - text/json
-        - application/*+json
-      produces:
-        - application/json
-      parameters:
-        - name: node
-          in: body
-          description: The node to update.
-          required: false
           schema:
-            $ref: '#/definitions/node'
-      responses:
-        '201':
-          description: Success
-  '/specif/v1.0/nodes/{id}':
+            $ref: '#/definitions/file'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
     delete:
       tags:
-        - Node
-      summary: Delete a node with the given ID.
-      operationId: DeleteNode
+        - file
+      summary: Delete the file; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      operationId: deleteFileById
       consumes: []
       produces:
         - application/json
       parameters:
         - name: id
           in: path
-          description: The node ID.
+          description: The file ID.
           required: true
           type: string
       responses:
         '200':
           description: Success
-  '/specif/v1.0/nodes/move/{nodeId}/to/{newParentId}/position/{position}':
-    put:
-      tags:
-        - Node
-      summary: Moves an existion node and all child nodes to a new parent.
-      operationId: '{FC0EF587-8E82-41B6-9149-4EF87EE21E6F}'
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: nodeId
-          in: path
-          description: The id of the node to move.
-          required: true
-          type: string
-        - name: newParentId
-          in: path
-          description: The id of the new parent.
-          required: true
-          type: string
-        - name: position
-          in: path
-          description: The desired node position.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-  /specif/v1.0/primitive-types:
-    get:
-      tags:
-        - PrimitiveTypes
-      summary: Returns a list with the names of the available primitive types.
-      operationId: GetPrimitiveTypeList
-      consumes: []
-      produces:
-        - application/json
-      parameters: []
-      responses:
-        '200':
-          description: List of primitive types suceessfull returned.
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              type: string
-  '/specif/v1.0/resources/{id}':
-    get:
-      tags:
-        - Resource
-      summary: Returns the latest version of the resource with the given ID.
-      operationId: GetResourceById
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The resource ID.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/Resource'
-  '/specif/v1.0/resources/{id}/revisions':
-    get:
-      tags:
-        - Resource
-      summary: Returns a list of all revisions for the resource with the given ID.
-      operationId: GetAllResourceRevisions
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Resource'
-  '/specif/v1.0/resources/{id}/revisions/{revision}':
-    get:
-      tags:
-        - Resource
-      summary: Returns a specific revision for the resource with the given ID.
-      operationId: GetResourceRevision
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '201':
-          description: Success
-          schema:
-            $ref: '#/definitions/Resource'
-  '/specif/v1.0/resources/{id}/branches/{branch}':
-    get:
-      tags:
-        - Resource
-      summary: Returns the latest revision for the resource with the given ID in the given branch.
-      operationId: GetLatestResourceRevisionInBranch
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-        - name: branch
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/Resource'
-  /specif/v1.0/resources:
-    post:
-      tags:
-        - Resource
-      summary: Adds a new resource to the SpecIF repository.
-      operationId: AddNewResource
-      consumes:
-        - application/json-patch+json
-        - application/json
-        - text/json
-        - application/*+json
-      produces:
-        - application/json
-      parameters:
-        - name: resource
-          in: body
-          description: ''
-          required: false
-          schema:
-            $ref: '#/definitions/Resource'
-      responses:
-        '201':
-          description: Success
-          schema:
-            $ref: '#/definitions/Resource'
-  /specif/v1.0/resource-classes:
-    get:
-      tags:
-        - ResourceClass
-      summary: Returns all resource classes with all available revisions.
-      operationId: GetAllResourceClasses
-      consumes: []
-      produces:
-        - application/json
-      parameters: []
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/ResourceClass'
         '400':
           description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/resource-classes/{id}':
-    get:
-      tags:
-        - ResourceClass
-      summary: Returns the main/latest revision of the resource class with the given ID.
-      operationId: GetResourceClassById
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/ResourceClass'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/resource-classes/{id}/revisions':
-    get:
-      tags:
-        - ResourceClass
-      summary: Returns all resource class revisions for the given id.
-      operationId: GetAllResourceClassRevisions
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/ResourceClass'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/resource-classes/{id}/revisions/{revision}':
-    get:
-      tags:
-        - ResourceClass
-      summary: Returns the resource class with the specific revision.
-      operationId: GetResourceClassRevision
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The resource class ID.
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: The resource class revision.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/ResourceClass'
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/{id}':
-    get:
-      tags:
-        - Statement
-      summary: Returns the main/latest revision of the statement nwith the given ID.
-      operationId: GetStatementById
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/Statement'
-  '/specif/v1.0/statements/{id}/revisions':
-    get:
-      tags:
-        - Statement
-      summary: Returns all available revisions for the statement wit the given ID.
-      operationId: GetAllStatementRevisions
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The statement id.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Resource'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/{id}/revisions/{revision}':
-    get:
-      tags:
-        - Statement
-      summary: Returns a specific revision for the statement with the given id.
-      operationId: GetStatementRevision
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The statement id.
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: The statement revision.
-          required: true
-          type: string
-      responses:
-        '201':
-          description: Success
-          schema:
-            $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/subject/{subjectId}':
-    get:
-      tags:
-        - Statement
-      summary: Returns all statements for the subject resource with the given ID and the main/latest subject revision.
-      operationId: GetStatementsForMainLatestSubject
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: subjectId
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/object/{objectId}':
-    get:
-      tags:
-        - Statement
-      summary: Returns all statements for the object resource with the given ID and the main/latest object revision.
-      operationId: GetStatementsForMainLatestObject
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: objectId
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/subject/{subjectId}/subject-revision/{revision}':
-    get:
-      tags:
-        - Statement
-      summary: Returns all statements for the subject resource with the given ID and the given subject revision.
-      operationId: GetStatementsBySubject
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: subjectId
-          in: path
-          description: ''
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/object/{objectId}/object-revision/{revision}':
-    get:
-      tags:
-        - Statement
-      summary: Returns all statements for the object resource with the given ID and the given object revision.
-      operationId: GetStatementsByObject
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: objectId
-          in: path
-          description: ''
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/resource/{resourceId}':
-    get:
-      tags:
-        - Statement
-      summary: Returns all statements for a resource with a given ID and main/latest revision - resource is uses as subject OR object for the statement.
-      operationId: GetAllStatementsForMainLatestResource
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: resourceId
-          in: path
-          description: The resource element ID.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statements/resource/{resourceId}/resource-revision/{revision}':
-    get:
-      tags:
-        - Statement
-      summary: Returns all statements for a resource with a given ID and teh given revision - resource is uses as subject OR object for the statement.
-      operationId: GetAllStatementsForResource
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: resourceId
-          in: path
-          description: The resource element ID.
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: The resource element revision.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  /specif/v1.0/statements:
-    post:
-      tags:
-        - Statement
-      summary: 'Add a new statement. If a statement with the given ID is still existant, a new revision is created automatically.'
-      operationId: AddNewStatement
-      consumes:
-        - application/json-patch+json
-        - application/json
-        - text/json
-        - application/*+json
-      produces:
-        - application/json
-      parameters:
-        - name: statemenet
-          in: body
-          description: The statement to create.
-          required: false
-          schema:
-            $ref: '#/definitions/Statement'
-      responses:
-        '201':
-          description: Success
-          schema:
-            $ref: '#/definitions/Statement'
-        '400':
-          description: Bad Request
-  /specif/v1.0/statement-classes:
-    get:
-      tags:
-        - StatementClass
-      summary: Returns all statement classes with all available revisions.
-      operationId: GetAllStatementClasses
-      consumes: []
-      produces:
-        - application/json
-      parameters: []
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/StatementClass'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statement-classes/{id}':
-    get:
-      tags:
-        - StatementClass
-      summary: Returns the main/latest revision of the statement class with the given ID.
-      operationId: GetStatementClassById
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/StatementClass'
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/statement-classes/{id}/revisions':
-    get:
-      tags:
-        - StatementClass
-      summary: Returns all statement class revisions for the given id.
-      operationId: GetAllStatementClassRevisions
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/StatementClass'
-  '/specif/v1.0/statement-classes/{id}/revisions/{revision}':
-    get:
-      tags:
-        - StatementClass
-      summary: Returns the statement class with the specific revision.
-      operationId: GetStatementClassRevision
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The statement class ID.
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: The statement class revision.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/StatementClass'
         '404':
           description: Not Found
 definitions:
@@ -1245,22 +938,22 @@ definitions:
       changedAt:
         format: date-time
         type: string
-  datatype:
+  dataType:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       description:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       type:
         type: string
       maxLength:
@@ -1279,7 +972,7 @@ definitions:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/EnumValue'
+          $ref: '#/definitions/enumValue'
       multiple:
         type: boolean
       changedAt:
@@ -1287,25 +980,25 @@ definitions:
         type: string
       changedBy:
         type: string
-  Revision:
+  revison:
     type: object
     properties: {}
-  Value:
+  value:
     type: object
     properties:
       languageValues:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/LanguageValue'
-  EnumValue:
+          $ref: '#/definitions/language'
+  enumValue:
     type: object
     properties:
       id:
         type: string
       title:
-        $ref: '#/definitions/Value'
-  LanguageValue:
+        $ref: '#/definitions/value'
+  language:
     type: object
     properties:
       text:
@@ -1318,16 +1011,16 @@ definitions:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       description:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       resource:
         type: object
       nodes:
@@ -1340,24 +1033,24 @@ definitions:
         type: string
       changedBy:
         type: string
-  propertyclass:
+  propertyClass:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       description:
-        $ref: '#/definitions/Value'
-      datatype:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/value'
+      dataType:
+        $ref: '#/definitions/key'
       multiple:
         type: boolean
       changedAt:
@@ -1365,31 +1058,31 @@ definitions:
         type: string
       changedBy:
         type: string
-  Key:
+  key:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
-  StatementClass:
+        $ref: '#/definitions/revison'
+  statementClass:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       description:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       extends:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/key'
       icon:
         type: string
       instantiation:
@@ -1397,11 +1090,11 @@ definitions:
         type: array
         items:
           type: string
-      propertyclasses:
+      propertyClasses:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Key'
+          $ref: '#/definitions/key'
       subjectClasses:
         uniqueItems: false
         type: array
@@ -1417,77 +1110,77 @@ definitions:
         type: string
       changedBy:
         type: string
-  Resource:
+  resource:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       class:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/key'
       description:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       properties:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Property'
+          $ref: '#/definitions/property'
       changedAt:
         format: date-time
         type: string
       changedBy:
         type: string
-  Property:
+  property:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       value:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       description:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       class:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/key'
       changedAt:
         format: date-time
         type: string
       changedBy:
         type: string
-  ResourceClass:
+  resourceClass:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       description:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       extends:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/key'
       icon:
         type: string
       isHeading:
@@ -1497,43 +1190,66 @@ definitions:
         type: array
         items:
           type: string
-      propertyclasses:
+      propertyClasses:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Key'
+          $ref: '#/definitions/key'
       changedAt:
         format: date-time
         type: string
       changedBy:
         type: string
-  Statement:
+  statement:
     type: object
     properties:
       id:
         type: string
       revision:
-        $ref: '#/definitions/Revision'
+        $ref: '#/definitions/revison'
       replaces:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Revision'
+          $ref: '#/definitions/revison'
       title:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       class:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/key'
       description:
-        $ref: '#/definitions/Value'
+        $ref: '#/definitions/value'
       subject:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/key'
       object:
-        $ref: '#/definitions/Key'
+        $ref: '#/definitions/key'
       properties:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Property'
+          $ref: '#/definitions/property'
+      changedAt:
+        format: date-time
+        type: string
+      changedBy:
+        type: string
+  file:
+    type: object
+    properties:
+      id:
+        type: string
+      revision:
+        $ref: '#/definitions/revison'
+      replaces:
+        uniqueItems: false
+        type: array
+        items:
+          $ref: '#/definitions/revison'
+      title:
+        $ref: '#/definitions/value'
+      description:
+        $ref: '#/definitions/value'
+      type:
+        $ref: '#/definitions/value'
       changedAt:
         format: date-time
         type: string

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10,50 +10,12 @@ info:
     name: Apache License 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0'
 paths:
-  '/specif/v1.0/dataTypes':
+  '/specif/v1.0/projects':
     get:
       tags:
-        - dataType
-      summary: Return all dataTypes.
-      operationId: getAllDataTypes
-      consumes: []
-      produces:
-        - application/json
-      parameters: []
-      responses:
-        '200':
-          description: List of data types suceessfully returned.
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/dataType'
-  '/specif/v1.0/dataTypes/{id}':
-    get:
-      tags:
-        - dataType
-      summary: Return the latest revision of the data type with the given ID.
-      operationId: getDataTypeById
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The data type ID.
-          required: true
-          type: string
-      responses:
-        '400':
-          description: Bad Request
-        '404':
-          description: Not Found
-  '/specif/v1.0/hierarchies':
-    get:
-      tags:
-        - hierarchy
-      summary: Get all hierarchies without nodes.
-      operationId: getAllHierarchies
+        - project
+      summary: Return all projects; to limit the size only root properties are delivered.
+      operationId: getAllProjects
       consumes: []
       produces:
         - application/json
@@ -65,11 +27,227 @@ paths:
             uniqueItems: false
             type: array
             items:
+              $ref: '#/definitions/project'
+    post:
+      tags:
+        - project
+      summary: Create a project with supplied elements; the supplied ID must not exist.
+      operationId: createProject
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '201':
+          description: Success
+  '/specif/v1.0/projects/{pid}':
+    get:
+      tags:
+        - project
+      summary: Return the project with the given ID; to limit the size only ??? are delivered.
+      operationId: getProjectById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    delete:
+      tags:
+        - project
+      summary: Delete the project with all content; the supplied ID must exist.
+      operationId: deleteProjectById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+  '/specif/v1.0/projects/{pid}/dataTypes':
+    get:
+      tags:
+        - dataType
+      summary: Return all dataTypes.
+      operationId: getAllDataTypes
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: List of dataTypes suceessfully returned.
+          schema:
+            uniqueItems: false
+            type: array
+            items:
+              $ref: '#/definitions/dataType'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    post:
+      tags:
+        - dataType
+      summary: Create a dataType; the supplied ID must not exist.
+      operationId: createDataType
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '201':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    put:
+      tags:
+        - dataType
+      summary: Update the dataType; the supplied ID must exist.
+      operationId: updateDataType
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+  '/specif/v1.0/projects/{pid}/dataTypes/{id}':
+    get:
+      tags:
+        - dataType
+      summary: Return the dataType with the given ID.
+      operationId: getDataTypeById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: The data type ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+    delete:
+      tags:
+        - dataType
+      summary: Delete the dataType; the supplied ID must exist.
+      operationId: deleteDataTypeById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+        - name: id
+          in: path
+          description: The hierarchy ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+  '/specif/v1.0/projects/{pid}/hierarchies':
+    get:
+      tags:
+        - hierarchy
+      summary: Get all hierarchies (root-nodes) without their sub-trees (nodes).
+      operationId: getAllHierarchies
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            uniqueItems: false
+            type: array
+            items:
               $ref: '#/definitions/node'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
     post:
       tags:
         - hierarchy
-      summary: Create a hierarchy with supplied nodes.
+      summary: Create a hierarchy (sub-tree) with supplied nodes; the supplied ID must not exist. ?parent=nodeId - the sub-tree will be inserted as first child; ?predecessor=nodeId - the sub-tree will be inserted after the specified node; no query - the sub-tree will be inserted as first element at root level.
       operationId: createHierarchy
       consumes:
         - application/json-patch+json
@@ -79,6 +257,11 @@ paths:
       produces:
         - application/json
       parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
         - name: hierarchy
           in: body
           description: ''
@@ -88,10 +271,14 @@ paths:
       responses:
         '201':
           description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
     put:
       tags:
         - hierarchy
-      summary: Update an existing hierarchy with supplied nodes.
+      summary: Update an existing hierarchy (sub-tree) with supplied nodes; the supplied ID must exist somewhere in any hierarchy.
       operationId: updateHierarchy
       consumes:
         - application/json-patch+json
@@ -101,6 +288,11 @@ paths:
       produces:
         - application/json
       parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
         - name: hierarchy
           in: body
           description: ''
@@ -110,16 +302,25 @@ paths:
       responses:
         '200':
           description: Success
-  '/specif/v1.0/hierarchies/{id}':
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
+  '/specif/v1.0/projects/{pid}/hierarchies/{id}':
     get:
       tags:
         - hierarchy
-      summary: Get hierarchy with a specific ID with all nodes.
+      summary: Get hierarchy (sub-tree) with all nodes; the supplied ID must exist somewhere in any hierarchy.
       operationId: getHierarchyById
       consumes: []
       produces:
         - application/json
       parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
         - name: id
           in: path
           description: The hierarchy ID.
@@ -130,15 +331,24 @@ paths:
           description: Success
           schema:
             $ref: '#/definitions/node'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
     delete:
       tags:
         - hierarchy
-      summary: Delete hierarchy with a specific ID with all nodes.
+      summary: Delete hierarchy (sub-tree) with all nodes; the supplied ID must exist somewhere in any hierarchy.
       operationId: deleteHierarchyById
       consumes: []
       produces:
         - application/json
       parameters:
+        - name: pid
+          in: path
+          description: The project ID.
+          required: true
+          type: string
         - name: id
           in: path
           description: The hierarchy ID.
@@ -147,8 +357,10 @@ paths:
       responses:
         '200':
           description: Success
-          schema:
-            $ref: '#/definitions/node'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found or No Permission
   '/specif/v1.0/nodes/root-nodes':
     get:
       tags:
@@ -351,7 +563,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found
+          description: Not Found or No Permission
   '/specif/v1.0/property-classes/{id}/revisions':
     get:
       tags:
@@ -997,6 +1209,14 @@ paths:
         '404':
           description: Not Found
 definitions:
+  project:
+    type: object
+    properties:
+      id:
+        type: string
+      changedAt:
+        format: date-time
+        type: string
   dataType:
     type: object
     properties:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -699,7 +699,7 @@ paths:
     delete:
       tags:
         - statement
-      summary: Delete the statement; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
+      summary: Delete the statement; the supplied ID must exist.
       operationId: deleteStatementById
       consumes: []
       produces:
@@ -935,6 +935,8 @@ definitions:
     properties:
       id:
         type: string
+      isExtension:
+        type: boolean  
       changedAt:
         format: date-time
         type: string
@@ -990,7 +992,7 @@ definitions:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/language'
+          $ref: '#/definitions/languageValue'
   enumValue:
     type: object
     properties:
@@ -998,7 +1000,7 @@ definitions:
         type: string
       title:
         $ref: '#/definitions/value'
-  language:
+  languageValue:
     type: object
     properties:
       text:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -91,12 +91,12 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/projects/{pid}/dataTypes':
+  '/specif/v1.0/projects/{pid}/datatypes':
     get:
       tags:
-        - dataType
+        - datatype
       summary: Return all data types.
-      operationId: getAllDataTypes
+      operationId: getalldatatypes
       consumes: []
       produces:
         - application/json
@@ -108,19 +108,19 @@ paths:
           type: string
       responses:
         '200':
-          description: List of dataTypes suceessfully returned.
+          description: List of datatypes suceessfully returned.
           schema:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/dataType'
+              $ref: '#/definitions/datatype'
         '400':
           description: Bad Request
     post:
       tags:
-        - dataType
+        - datatype
       summary: Create a data type; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
-      operationId: createDataType
+      operationId: createdatatype
       consumes:
         - application/json-patch+json
         - application/json
@@ -141,9 +141,9 @@ paths:
           description: Bad Request
     put:
       tags:
-        - dataType
+        - datatype
       summary: Update the data type; the supplied ID must exist.
-      operationId: updateDataType
+      operationId: updatedatatype
       consumes:
         - application/json-patch+json
         - application/json
@@ -164,12 +164,12 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/projects/{pid}/dataTypes/{id}':
+  '/specif/v1.0/projects/{pid}/datatypes/{id}':
     get:
       tags:
-        - dataType
+        - datatype
       summary: Return the data type with the given ID.
-      operationId: getDataTypeById
+      operationId: getdatatype
       consumes: []
       produces:
         - application/json
@@ -193,9 +193,9 @@ paths:
           description: Not Found
     delete:
       tags:
-        - dataType
+        - datatype
       summary: Delete the data type; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
-      operationId: deleteDataTypeById
+      operationId: deletedatatype
       consumes: []
       produces:
         - application/json
@@ -219,12 +219,12 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  /specif/v1.0/propertyClasses:
+  /specif/v1.0/propertyclasses:
     get:
       tags:
-        - propertyClass
+        - propertyclass
       summary: Return all property classes.
-      operationId: GetAllPropertyClasses
+      operationId: Getallpropertyclasses
       consumes: []
       produces:
         - application/json
@@ -236,14 +236,14 @@ paths:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/PropertyClass'
+              $ref: '#/definitions/propertyclass'
         '400':
           description: Bad Request
     post:
       tags:
-        - propertyClass
+        - propertyclass
       summary: Create a property class; the supplied ID must be unique in the project scope. If no ID is supplied, it is generated before insertion.
-      operationId: createPropertyClass
+      operationId: createpropertyclass
       consumes:
         - application/json-patch+json
         - application/json
@@ -264,9 +264,9 @@ paths:
           description: Bad Request
     put:
       tags:
-        - propertyClass
+        - propertyclass
       summary: Update the property class; the supplied ID must exist.
-      operationId: updatePropertyClass
+      operationId: updatepropertyclass
       consumes:
         - application/json-patch+json
         - application/json
@@ -287,12 +287,12 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/propertyClasses/{id}':
+  '/specif/v1.0/propertyclasses/{id}':
     get:
       tags:
-        - propertyClass
+        - propertyclass
       summary: Return the property class with the given ID.
-      operationId: GetPropertyClassById
+      operationId: Getpropertyclass
       consumes: []
       produces:
         - application/json
@@ -306,16 +306,16 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/PropertyClass'
+            $ref: '#/definitions/propertyclass'
         '400':
           description: Bad Request
         '404':
           description: Not Found or No Permission
     delete:
       tags:
-        - propertyClass
+        - propertyclass
       summary: Delete the property class; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
-      operationId: deletePropertyClassById
+      operationId: deletepropertyclass
       consumes: []
       produces:
         - application/json
@@ -1245,7 +1245,7 @@ definitions:
       changedAt:
         format: date-time
         type: string
-  dataType:
+  datatype:
     type: object
     properties:
       id:
@@ -1340,7 +1340,7 @@ definitions:
         type: string
       changedBy:
         type: string
-  PropertyClass:
+  propertyclass:
     type: object
     properties:
       id:
@@ -1356,7 +1356,7 @@ definitions:
         $ref: '#/definitions/Value'
       description:
         $ref: '#/definitions/Value'
-      dataType:
+      datatype:
         $ref: '#/definitions/Key'
       multiple:
         type: boolean
@@ -1397,7 +1397,7 @@ definitions:
         type: array
         items:
           type: string
-      propertyClasses:
+      propertyclasses:
         uniqueItems: false
         type: array
         items:
@@ -1497,7 +1497,7 @@ definitions:
         type: array
         items:
           type: string
-      propertyClasses:
+      propertyclasses:
         uniqueItems: false
         type: array
         items:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -10,30 +10,30 @@ info:
     name: Apache License 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0'
 paths:
-  /specif/v1.0/data-types:
+  '/specif/v1.0/dataTypes':
     get:
       tags:
-        - DataType
-      summary: Returns all data types with all available revisions.
-      operationId: GetAllDataTypes
+        - dataType
+      summary: Return all dataTypes.
+      operationId: getAllDataTypes
       consumes: []
       produces:
         - application/json
       parameters: []
       responses:
         '200':
-          description: List of data types suceessfull returned.
+          description: List of data types suceessfully returned.
           schema:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/DataType'
-  '/specif/v1.0/data-types/{id}':
+              $ref: '#/definitions/dataType'
+  '/specif/v1.0/dataTypes/{id}':
     get:
       tags:
-        - DataType
-      summary: Returns the latest revision of the data type with the given ID.
-      operationId: GetDataTypeById
+        - dataType
+      summary: Return the latest revision of the data type with the given ID.
+      operationId: getDataTypeById
       consumes: []
       produces:
         - application/json
@@ -48,62 +48,12 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/data-types/{id}/revisions':
+  '/specif/v1.0/hierarchies':
     get:
       tags:
-        - DataType
-      summary: Returns all data type revisions for the given id.
-      operationId: GetAllDatatypeRevisions
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: ''
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            uniqueItems: false
-            type: array
-            items:
-              $ref: '#/definitions/DataType'
-  '/specif/v1.0/data-types/{id}/revisions/{revision}':
-    get:
-      tags:
-        - DataType
-      summary: Returns the data type with the specific revision.
-      operationId: GetDataTypeRevision
-      consumes: []
-      produces:
-        - application/json
-      parameters:
-        - name: id
-          in: path
-          description: The data type ID.
-          required: true
-          type: string
-        - name: revision
-          in: path
-          description: The data type revision.
-          required: true
-          type: string
-      responses:
-        '200':
-          description: Success
-          schema:
-            $ref: '#/definitions/DataType'
-        '404':
-          description: Not Found
-  /specif/v1.0/hierarchies:
-    get:
-      tags:
-        - Hierarchy
-      summary: Get all hierarchies.
-      operationId: GetAllHierarchies
+        - hierarchy
+      summary: Get all hierarchies without nodes.
+      operationId: getAllHierarchies
       consumes: []
       produces:
         - application/json
@@ -115,34 +65,12 @@ paths:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/Node'
-    put:
-      tags:
-        - Hierarchy
-      summary: Update an existing hierarchy.
-      operationId: UpdateHierarchy
-      consumes:
-        - application/json-patch+json
-        - application/json
-        - text/json
-        - application/*+json
-      produces:
-        - application/json
-      parameters:
-        - name: hierarchy
-          in: body
-          description: ''
-          required: false
-          schema:
-            $ref: '#/definitions/Node'
-      responses:
-        '200':
-          description: Success
+              $ref: '#/definitions/node'
     post:
       tags:
-        - Hierarchy
-      summary: Add a new hierarchy.
-      operationId: AddNewHierarchy
+        - hierarchy
+      summary: Create a hierarchy with supplied nodes.
+      operationId: createHierarchy
       consumes:
         - application/json-patch+json
         - application/json
@@ -156,16 +84,38 @@ paths:
           description: ''
           required: false
           schema:
-            $ref: '#/definitions/Node'
+            $ref: '#/definitions/node'
+      responses:
+        '201':
+          description: Success
+    put:
+      tags:
+        - hierarchy
+      summary: Update an existing hierarchy with supplied nodes.
+      operationId: updateHierarchy
+      consumes:
+        - application/json-patch+json
+        - application/json
+        - text/json
+        - application/*+json
+      produces:
+        - application/json
+      parameters:
+        - name: hierarchy
+          in: body
+          description: ''
+          required: false
+          schema:
+            $ref: '#/definitions/node'
       responses:
         '200':
           description: Success
   '/specif/v1.0/hierarchies/{id}':
     get:
       tags:
-        - Hierarchy
-      summary: Get hierarchy with a specific ID.
-      operationId: GetHierarchyById
+        - hierarchy
+      summary: Get hierarchy with a specific ID with all nodes.
+      operationId: getHierarchyById
       consumes: []
       produces:
         - application/json
@@ -179,8 +129,27 @@ paths:
         '200':
           description: Success
           schema:
-            $ref: '#/definitions/Node'
-  /specif/v1.0/nodes/root-nodes:
+            $ref: '#/definitions/node'
+    delete:
+      tags:
+        - hierarchy
+      summary: Delete hierarchy with a specific ID with all nodes.
+      operationId: deleteHierarchyById
+      consumes: []
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          description: The hierarchy ID.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/node'
+  '/specif/v1.0/nodes/root-nodes':
     get:
       tags:
         - Node
@@ -197,7 +166,7 @@ paths:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/Node'
+              $ref: '#/definitions/node'
   '/specif/v1.0/nodes/{parentNodeId}/child-nodes':
     get:
       tags:
@@ -219,7 +188,7 @@ paths:
             uniqueItems: false
             type: array
             items:
-              $ref: '#/definitions/Node'
+              $ref: '#/definitions/node'
         '400':
           description: Bad Request
         '404':
@@ -248,7 +217,7 @@ paths:
           description: The new child node.
           required: false
           schema:
-            $ref: '#/definitions/Node'
+            $ref: '#/definitions/node'
       responses:
         '200':
           description: Success
@@ -271,7 +240,7 @@ paths:
           description: The node to update.
           required: false
           schema:
-            $ref: '#/definitions/Node'
+            $ref: '#/definitions/node'
       responses:
         '201':
           description: Success
@@ -1028,7 +997,7 @@ paths:
         '404':
           description: Not Found
 definitions:
-  DataType:
+  dataType:
     type: object
     properties:
       id:
@@ -1095,7 +1064,7 @@ definitions:
         type: string
       language:
         type: string
-  Node:
+  node:
     type: object
     properties:
       id:
@@ -1117,7 +1086,7 @@ definitions:
         uniqueItems: false
         type: array
         items:
-          $ref: '#/definitions/Node'
+          $ref: '#/definitions/node'
       changedAt:
         format: date-time
         type: string

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -28,6 +28,10 @@ paths:
             type: array
             items:
               $ref: '#/definitions/project'
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
     post:
       tags:
         - project
@@ -44,6 +48,10 @@ paths:
       responses:
         '201':
           description: Success
+        '400':
+          description: Bad Request
+        '404':
+          description: Not Found
   '/specif/v1.0/projects/{pid}':
     get:
       tags:
@@ -65,7 +73,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
     delete:
       tags:
         - project
@@ -86,7 +94,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
   '/specif/v1.0/projects/{pid}/dataTypes':
     get:
       tags:
@@ -113,7 +121,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
     post:
       tags:
         - dataType
@@ -138,7 +146,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
     put:
       tags:
         - dataType
@@ -163,7 +171,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
   '/specif/v1.0/projects/{pid}/dataTypes/{id}':
     get:
       tags:
@@ -190,11 +198,11 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
     delete:
       tags:
         - dataType
-      summary: Delete the dataType; the supplied ID must exist.
+      summary: Delete the dataType; the supplied ID must exist. Return an error if there are depending model elements. ?mode=forced results in deleting all directly and indirectly depending model elements.
       operationId: deleteDataTypeById
       consumes: []
       produces:
@@ -216,7 +224,9 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
+        '901':
+          description: Is Referenced
   '/specif/v1.0/projects/{pid}/hierarchies':
     get:
       tags:
@@ -243,7 +253,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
     post:
       tags:
         - hierarchy
@@ -274,7 +284,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
     put:
       tags:
         - hierarchy
@@ -305,7 +315,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
   '/specif/v1.0/projects/{pid}/hierarchies/{id}':
     get:
       tags:
@@ -334,7 +344,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
     delete:
       tags:
         - hierarchy
@@ -360,7 +370,7 @@ paths:
         '400':
           description: Bad Request
         '404':
-          description: Not Found or No Permission
+          description: Not Found
   '/specif/v1.0/nodes/root-nodes':
     get:
       tags:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -194,7 +194,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  '/specif/v1.0/dataTypes/{id}/allRevisions':
+  '/specif/v1.0/dataTypes/{id}/revisions':
     get:
       tags:
         - dataType
@@ -324,7 +324,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  '/specif/v1.0/propertyClasses/{id}/allRevisions':
+  '/specif/v1.0/propertyClasses/{id}/revisions':
     get:
       tags:
         - propertyClass
@@ -454,7 +454,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  '/specif/v1.0/resourceClasses/{id}/allRevisions':
+  '/specif/v1.0/resourceClasses/{id}/revisions':
     get:
       tags:
         - resourceClass
@@ -584,7 +584,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  '/specif/v1.0/statementClasses/{id}/allRevisions':
+  '/specif/v1.0/statementClasses/{id}/revisions':
     get:
       tags:
         - statementClass
@@ -714,7 +714,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  '/specif/v1.0/resources/{id}/allRevisions':
+  '/specif/v1.0/resources/{id}/revisions':
     get:
       tags:
         - resource
@@ -842,7 +842,7 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/statements/{id}/allRevisions':
+  '/specif/v1.0/statements/{id}/revisions':
     get:
       tags:
         - statement
@@ -974,7 +974,7 @@ paths:
           description: Bad Request
         '404':
           description: Not Found
-  '/specif/v1.0/hierarchies/{id}/allRevisions':
+  '/specif/v1.0/hierarchies/{id}/revisions':
     get:
       tags:
         - hierarchy
@@ -1104,7 +1104,7 @@ paths:
           description: Not Found
         '901':
           description: Is Referenced
-  '/specif/v1.0/files/{id}/allRevisions':
+  '/specif/v1.0/files/{id}/revisions':
     get:
       tags:
         - file


### PR DESCRIPTION
Oliver, I have made changes to dataTypes and hierarchies according to my proposals. Idea is to use the terms of the schema and no others. What do you think?  
In particular:
- I have not yet added the projects to the path ... 
- I have removed the revisions from it in favor of a query string. The idea is that specifying a revision is sort of filtering. We could also filter for types, classes or similar.